### PR TITLE
Improve error logging

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -31,7 +31,7 @@ android {
     compileSdkVersion 27
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 21
         targetSdkVersion 27
         versionCode 7
         versionName "1.0.0"

--- a/library/src/main/java/es/voghdev/pdfviewpager/library/adapter/BasePDFPagerAdapter.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/adapter/BasePDFPagerAdapter.java
@@ -183,11 +183,23 @@ public class BasePDFPagerAdapter extends PagerAdapter {
         int globalPosition = 0;
 
         if (localPosition.pdfIndex >= renderers.size()) {
-            throw new IndexOutOfBoundsException("PDF index is greater than number of PDFs");
+            throw new IndexOutOfBoundsException(
+                    String.format(
+                            "PDF index (%d) is greater than number of PDFs (%d)",
+                            localPosition.pdfIndex,
+                            renderers.size()
+                    )
+            );
         }
 
         if (localPosition.pageIndex >= renderers.get(localPosition.pdfIndex).getPageCount()) {
-            throw new IndexOutOfBoundsException("Page index is greater than the PDF page count");
+            throw new IndexOutOfBoundsException(
+                    String.format(
+                            "Page index (%d) is greater than the PDF page count (%d)",
+                            localPosition.pageIndex,
+                            renderers.get(localPosition.pdfIndex).getPageCount()
+                    )
+            );
         }
 
         for (int i = 0; i < localPosition.pdfIndex; i++) {


### PR DESCRIPTION
When we get an 'index out of bounds' exception, its usually pretty
helpful to know the index we're trying to access and the total
number of elements in the array. So this change adds this info.