### PR TITLE
Increase minimum Android SDK to 21

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "es.voghdev.pdfviewpager"
-        minSdkVersion 15
+        minSdkVersion 21
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
     }
 


### PR DESCRIPTION
We use features in this project which require a minimum SDK version of 21 so we should enforce it in the Android manifest.